### PR TITLE
Was able to run plugin with this changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ export default defineConfig({
     setupFiles: ["vitest-react-native/setup"],
     // this is required for this plugin to work
     globals: true,
+    server: {
+      deps: {
+          external: ["react-native"],
+      },
+    },
   },
 });
 ```

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ export default defineConfig({
     globals: true,
     server: {
       deps: {
-          external: ["react-native"],
+        external: ["react-native"],
       },
     },
   },

--- a/packages/vitest-react-native/plugin.js
+++ b/packages/vitest-react-native/plugin.js
@@ -25,6 +25,11 @@ module.exports = () => {
         test: {
           setupFiles: [resolve(__dirname, "setup.js")],
           globals: true,
+          server: {
+            deps: {
+              external: ["react-native"],
+            },
+          },
         },
       };
     },

--- a/packages/vitest-react-native/setup.js
+++ b/packages/vitest-react-native/setup.js
@@ -66,7 +66,7 @@ const transformCode = (code) => {
       format: "cjs",
       platform: "node",
     })
-    .code.replace(platformRegexp, 'require("$1.ios")');
+    .code;
 };
 
 const normalize = (path) => path.replace(/\\/g, "/");
@@ -122,7 +122,7 @@ addHook(
     return processReactNative(code, filename)
   },
   {
-    exts: [".js"],
+    exts: [".js", ".ios.js"],
     ignoreNodeModules: false,
     matcher: (id) => {
       const path = normalize(id)


### PR DESCRIPTION
1) Currently, vitest automatically attempts to transpile react-native, which leads to errors due to its inability to understand flow syntax. To resolve this, it's necessary to add react-native to `server.deps.external`.

2) Not all code was being transpiled as expected due to the lack of a `.ios.js` extension in the `pirates.addHook`. And since .ios.js is a lookup extension, there’s no need to replace it within the code.

3) It seems that `resolve.conditions` doesn’t serve any purpose, so I’ve removed it.